### PR TITLE
fix: when reset value, the options will reset now

### DIFF
--- a/src/el-select-area.vue
+++ b/src/el-select-area.vue
@@ -204,6 +204,7 @@ export default {
       let columnNum = AREA[type].index
       this.$set(this.values, columnNum, {code: '', name: '', type: type})
       this.$set(this.indexs, columnNum, '')
+      columnNum > 0 && this.$set(this.columns, columnNum, {})
     },
     // 兼容旧的输出
     emitEvent() {


### PR DESCRIPTION
Closes #8

- fix: A bug fix

## Why
Because the reset function should reset the select options too.

## Test
On preview changes

