### PR TITLE
fix: 默认值为空数组，但使用resetFields重置表单后，值不为空数组

### DIFF
--- a/src/el-select-area.vue
+++ b/src/el-select-area.vue
@@ -208,26 +208,28 @@ export default {
     },
     // 兼容旧的输出
     emitEvent() {
+      const type = this.type
       let result
 
-      if (this.type === 'all') {
-        result = this.values.map(item => {
-          const obj = {}
-          item.code && (obj[item.code] = item.name)
-          return obj
-        })
-      }
+      if (type === 'all') {
+        result = this.values
+          .map(item => {
+            const obj = {}
+            item.code && (obj[item.code] = item.name)
+            return obj
+          })
+          .filter(v => Object.keys(v).length)
+      } else {
+        if (type === 'code') {
+          result = this.values.map(item => item.code)
+        } else if (type === 'text') {
+          result = this.values.map(item => item.name)
+        }
 
-      if (this.type === 'code') {
-        result = this.values.map(item => item.code)
-      }
-
-      if (this.type === 'text') {
-        result = this.values.map(item => item.name)
+        result = result.filter(v => v)
       }
 
       result = result.slice(0, +this.level + 1)
-
       /**
        * input事件仅为了绑定v-model, 不了解v-model机制请勿随意调用
        * @property {array} result

--- a/src/el-select-area.vue
+++ b/src/el-select-area.vue
@@ -37,6 +37,12 @@ const AREA = {
   }
 }
 
+const TYPE = {
+  all: 'all',
+  code: 'code',
+  text: 'text'
+}
+
 function isCode(value = '') {
   return /^\d{6,}$/.test(value)
 }
@@ -211,7 +217,7 @@ export default {
       const type = this.type
       let result
 
-      if (type === 'all') {
+      if (type === TYPE.all) {
         result = this.values
           .map(item => {
             const obj = {}
@@ -220,9 +226,9 @@ export default {
           })
           .filter(v => Object.keys(v).length)
       } else {
-        if (type === 'code') {
+        if (type === TYPE.code) {
           result = this.values.map(item => item.code)
-        } else if (type === 'text') {
+        } else if (type === TYPE.text) {
           result = this.values.map(item => item.name)
         }
 
@@ -230,6 +236,7 @@ export default {
       }
 
       result = result.slice(0, +this.level + 1)
+
       /**
        * input事件仅为了绑定v-model, 不了解v-model机制请勿随意调用
        * @property {array} result


### PR DESCRIPTION
close #10

- fix: 使用resetFields重置表单后的值不为空数组

## Why
在配合form-renderer使用时，绑定默认值为空数组，但是使用resetFields重置后，值不为空数组，而是在 type 为 all 的情况下，值为[{}, {}, {}]，在 type 为 code 或 text 情况下，值为['', '', '']

## How
把将要 emit 的值，过滤一下，把空对象或空字符串过滤掉

You may use xmind or other mind map to show you logic
![image](https://user-images.githubusercontent.com/26338853/60262176-20c7c400-9910-11e9-8cfb-38047a4a2c85.png)

## Test
默认值设置为空数组，type 为 code 或 text 或 all 的情况下 ，触发resetFields，重置后的值为空数组
默认值不为空数组，触发resetFields可以重置为对应的值

## After
![GIF](https://user-images.githubusercontent.com/26338853/60408867-4fd18480-9bf3-11e9-9b5a-08c4b06cee78.gif)

