### PR TITLE
fix: 更改省级选择器时，应该重置市级和区级选择器

### DIFF
--- a/src/el-select-area.vue
+++ b/src/el-select-area.vue
@@ -205,8 +205,7 @@ export default {
         this.indexs.splice(i, 1, 0)
         this.cityChange(this.values[i])
       } else {
-        this.indexs.splice(i, 1, '')
-        this.indexs.splice(i + 1, 1, '')
+        this.indexs.splice(i, 2, ['', ''])
       }
     },
 

--- a/src/el-select-area.vue
+++ b/src/el-select-area.vue
@@ -206,6 +206,7 @@ export default {
         this.cityChange(this.values[i])
       } else {
         this.indexs.splice(i, 1, '')
+        this.indexs.splice(i + 1, 1, '')
       }
     },
 


### PR DESCRIPTION
## Why
fix #58 

## How
- 当改变省级时，重置市与区选择器（最小实现）

## Test
![select-area-auto-fill](https://user-images.githubusercontent.com/21327913/67178205-6a2ea880-f404-11e9-85d1-1a1583500ad8.gif)
